### PR TITLE
Fix URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ sudo apt install fuse libfuse-dev libicu-dev bzip2 libbz2-dev cmake gcc-c++ git 
 Clone the repository:
 ```
 git clone https://github.com/kholia/apfs2john.git
-cd apfs-fuse
+cd apfs2john
 git submodule init
 git submodule update
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ sudo apt install fuse libfuse-dev libicu-dev bzip2 libbz2-dev cmake gcc-c++ git 
 ```
 Clone the repository:
 ```
-git clone https://github.com/sgan81/apfs-fuse.git
+git clone https://github.com/kholia/apfs2john.git
 cd apfs-fuse
 git submodule init
 git submodule update


### PR DESCRIPTION
The section on cloning the repository contained instructions to clone apfs-fuse rather than apfs2john.